### PR TITLE
Added *promise-keep-specials*

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -17,5 +17,17 @@
            #:multiple-promise-bind
            #:wait
            #:adolist
-           #:promise-handler-case))
+           #:promise-handler-case
 
+           ;; cl-async-future compatibility classes/functions/macros
+           #:future
+           #:future-finished-p
+           #:make-future
+           #:lookup-forwarded-future
+           #:futurep
+           #:reset-future
+           #:multiple-future-bind
+           #:future-handler-case
+           #:wait-for
+
+           #:*promise-keep-specials*))


### PR DESCRIPTION
Sometimes it's desirable to keep some kind of context available via special vars during execution of a promise chain. For instance one may want to keep http request related context while serving a request in a web app. I added _promise-keep-specials_ special var that can be used for such purposes:

``` cl
(pushnew '*my-var* bb:*promise-keep-specials*)
```

Several notes:
1. Due to extra wrapping of callbacks/errbacks, this slightly changes the semantics of attach-errback - namely, it no longer can detect whether the callback was already added. Don't know whether that's critical. For purposes of promise forwarding, the non-wrapping version named do-attach-errback is used.
2. I thought about making alet/alet\* bindings of special vars work in such way that these vars are auto-registered in _promise-keep-specials_ while executing any code related to that alet/alet\* form, but couldn't quite wrap my head around it (how to do it properly and whether this is right thing at all)
3. (As a side note) there was an unused gensym var in alet macro, fixed it too.
