### PR TITLE
Fix wrap-callback

### DIFF
--- a/promise.lisp
+++ b/promise.lisp
@@ -41,7 +41,8 @@
                (vars (append bound (remove-if #'boundp all-vars)))
                (vals (mapcar #'symbol-value bound)))
           #'(lambda (&rest args)
-              (progv vars vals (apply callback args)))))))
+              (let ((*promise-keep-specials* all-vars))
+                (progv vars vals (apply callback args))))))))
 
 (defmethod print-object ((promise promise) s)
   (print-unreadable-object (promise s :type t :identity t)


### PR DESCRIPTION
Without this fix  _promise-keep-specials_ works only for first link of the promise chain.
