### PR TITLE
Fix handling of long promise forwarding chains.

### DIFF
--- a/promise.lisp
+++ b/promise.lisp
@@ -179,6 +179,7 @@
    added to the new promise-to if added to the promise-from."
   ;; a promise "returned" another promise. reattach the callbacks/errbacks from
   ;; the original promise onto the returned one
+  (setf promise-to (lookup-forwarded-promise promise-to))
   (dolist (cb (reverse (promise-callbacks promise-from)))
     (do-add-callback promise-to cb))
   (dolist (errback (reverse (promise-errbacks promise-from)))
@@ -337,7 +338,7 @@
           (lambda (&rest _)
             (declare (ignore _))
             (apply resolver args)))))))
-  
+
 
 (defmacro finally (promise-gen &body body)
   "Run the body form whether the given promise has a value or an error."

--- a/syntax.lisp
+++ b/syntax.lisp
@@ -124,6 +124,7 @@
                                      binding))))
     `(attach ,promise-gen
        (lambda (&rest ,args)
+         (declare (ignorable ,args))
          (let (,@bindings)
            ;; ignore any nil bindings
            ,(when ignore-bindings
@@ -158,4 +159,3 @@
                   collect `(nil ,head)
                   else do (setf last head))
        ,last)))
-

--- a/test/promise.lisp
+++ b/test/promise.lisp
@@ -508,3 +508,21 @@
     (is (equal '((:caught1 error) (:ok 42))
                (nreverse log)))))
 
+(test long-forward-chain
+  (multiple-value-bind (log)
+      (async-let ((log '()))
+        (let ((n 0))
+          (flet ((next-step ()
+                   (push (incf n) log)
+                   (bb:attach
+                    nil
+                    #'(lambda (x)
+                        (declare (ignore x))
+                        (with-promise (resolve reject)
+                          (as:with-delay ()
+                            (resolve)))))))
+            (bb:wait
+                (bb:wait (next-step)
+                  (next-step))
+              (next-step)))))
+    (is (equal '(1 2 3) (nreverse log)))))


### PR DESCRIPTION
In the case of more-than-one-hop-long promise forwarding chains,
it was possible to lose some callbacks. See the test case.
My brain almost melted before I discovered that, well,
blackbird "accidentally a callback".