### PR TITLE
Small fixes.

### DIFF
--- a/promise.lisp
+++ b/promise.lisp
@@ -156,7 +156,6 @@
         ;; return a promise that's fired with the return value of the error
         ;; handler
         (let ((forwarded-promise (lookup-forwarded-promise promise))
-              (new-promise (make-promise))
               (wrapped (if (consp errback)
                            errback
                            (cons new-promise errback))))

--- a/util.lisp
+++ b/util.lisp
@@ -114,7 +114,7 @@
     - :finally"
   (flet ((transform-op (promise op)
            (case (car op)
-             ((or :then :attach)
+             ((:then :attach)
               `(multiple-promise-bind ,(cadr op) ,promise ,@(cddr op)))
              (:map
               `(amap (lambda ,(cadr op) ,@(cddr op)) ,promise))
@@ -125,7 +125,7 @@
               `(afilter (lambda ,(cadr op) ,@(cddr op)) ,promise))
              (:all
               `(all ,promise))
-             ((or :catch :catcher)
+             ((:catch :catcher)
               `(do-catch ,promise (lambda ,(cadr op) ,@(cddr op))))
              (:finally
               `(finally ,promise ,@(cdr op)))


### PR DESCRIPTION
I'm not so sure about the removal of `new-promise`, but all tests still succeed and there's already a variable of that name at the top of the function, so it looks like that one was overlooked.